### PR TITLE
Address DeprecationWarning regarding collections.abc

### DIFF
--- a/inifile.py
+++ b/inifile.py
@@ -3,8 +3,11 @@ import sys
 import uuid
 import errno
 import tempfile
-
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 
 PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
With the current code, Python 3.9 issues this DeprecationWarning:

    Using or importing the ABCs from 'collections' instead of from
    'collections.abc' is deprecated since Python 3.3, and in 3.10 it
    will stop working

(Python 3.8 issues the same warning, except it reports that
"... in 3.9 it will stop working" — so who knows exactly when it
will stop working?)

This fixes that.