### PR TITLE
Fix IniData.__len__

### DIFF
--- a/inifile.py
+++ b/inifile.py
@@ -331,8 +331,11 @@ class IniData(MutableMapping):
     def __len__(self):
         rv = len(self._primary)
         for key, value in iteritems(self._changes):
-            if key in self._primary and value is not None:
-                rv += 1
+            if key in self._primary:
+                if value is None:
+                    rv -= 1  # key was deleted
+            elif value is not None:
+                rv += 1  # key was added
         return rv
 
     def get(self, name, default=None):

--- a/test_inifile.py
+++ b/test_inifile.py
@@ -1,0 +1,23 @@
+import pytest
+
+from inifile import IniData
+from inifile import IniFile
+
+
+def test():
+    cfg = IniFile("hello.ini")
+    assert cfg["foo.value"] == "42"
+
+
+def test_IniData_len():
+    data = IniData({"a": "aval"})
+    assert len(data) == 1
+    data["a"] += "more"
+    assert sum(1 for _ in data) == 1
+    assert len(data) == 1
+    data["b"] = "bval"
+    assert len(data) == 2
+    del data["a"]
+    assert len(data) == 1
+    del data["b"]
+    assert len(data) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+minversion = 3
+envlist = py27,py36,py37,py38,py39,py310,py311
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest -W error


### PR DESCRIPTION
There is a logic error in `IniData.__len__`

https://github.com/mitsuhiko/python-inifile/blob/dbdf3f319e6ef76dfa70b536defe916286a84f78/inifile.py#L331-L336

The loop over `self._changes` increments the length when `_changes` has a key that is _already_ in `_primary`.  That is incorrect.  It should be incrementing the length when the key _is not_ in `_primary`.

Also, the length should be decremented when the key in is `_primary` but the value is `None`. These represent keys that have been deleted.

Also included here are some rudimentary tests.